### PR TITLE
Fix/replace two paper links

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
       <ul>
         <li>
           <h3 id="speaker-1"><a href="https://twitter.com/alexeyraspopov">Alexey Raspopov</a></h3>
-          <p>Paper: <a href="http://www.eden-study.org/articles/2006/abstraction-classes-sw-design_ieesw.pdf">Abstraction Classes in Software Design</a></p>
+          <p>Paper: <a href="http://dces.essex.ac.uk/technical-reports/2004/csm-411.pdf">Abstraction Classes in Software Design</a></p>
         </li>
         <li>
           <h3 id="speaker-2"><a href="https://github.com/Bodigrim">Andrew Lelechenko</a></h3>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
         </li>
         <li>
           <h3 id="speaker-3"><a href="https://twitter.com/darkproger">Vladimir Kirilov</a></h3>
-          <p>Paper: <a href="http://ieeexplore.ieee.org/document/58323/">30 Years of Adaptive Neural Networks: Perceptron, Madaline, and Backpropagation</a></p>
+          <p>Paper: <a href="https://web.stanford.edu/class/ee373b/30years.pdf">30 Years of Adaptive Neural Networks: Perceptron, Madaline, and Backpropagation</a></p>
         </li>
       </ul>
     </section>


### PR DESCRIPTION
- Fix a link to the “Abstraction Classes in Software Design” paper, that currently returns 404 — this PDF is hosted by one of the author's university, so should be ok from the legal point of view (IANAL!)
- Replace paywall IEEE link to the “30 Years of Adaptive Neural Networks” paper with a link to PDF hosted by Stanford's website — this may be a bit shady, but it's what Google has found and it's really old, so maybe we¹ could get away with this (but again, IANAL)
# 

¹ — actually, you :smiley: 
